### PR TITLE
chore: replace CLI-based PR creation with create-pr action

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ jobs:
         
       - name: Create Pull Request
         if: ${{ steps.pr-check.outputs.skip_pr_creation == 'false' }}
-        run: |
-          gh pr create --title "Feature: ${{ github.ref_name }}" --body "Adds new feature branch."
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: owen-6936/create-pr@v1.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{github.ref_name}}
+          base-branch: main
 ````
 
 -----


### PR DESCRIPTION
- Swap out `gh pr create` CLI command with `owen-6936/create-pr@v1.0.0` GitHub Action

- Simplify workflow and improve portability by removing CLI dependency

- Update example workflow in README accordingly